### PR TITLE
Add total score progress bars

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,6 +142,10 @@
         });
       }
 
+      function getProgress(i, totals = getTotals()) {
+        return Math.min(1, (totals[i] || 0) / 100);
+      }
+
       // Jugadores que pueden seguir: no superaron 100 y no están enganchados
       function getJugadoresVivos() {
         const totals = getTotals();
@@ -476,16 +480,24 @@
         for (let i = 0; i < getPlayerCount(); i++) {
           let puedeEnganchar = shouldShowEnganchar(i);
           const textColor = getContrastColor(playerColors[i]);
+          const progress = getProgress(i, totals);
           tfootRow.innerHTML += `<td data-col="${i}" class="px-2 py-2 font-semibold ${
             isManualEnganchado(i) ? "enganchado" : ""
           }" style="background-color:${playerColors[i]};color:${textColor};">
+      <div class="flex items-center gap-1">
         <span>${totals[i]}</span>
         ${
           puedeEnganchar
-            ? `<button class="enganchar-btn ml-2 px-2 py-1 bg-yellow-500 text-white text-xs rounded animate-fadein" data-idx="${i}" aria-label="Enganchar a ${escapeHtml(playerNames[i])}">Enganchar</button>`
+            ? `<button class="enganchar-btn ml-2 px-2 py-1 bg-yellow-500 text-white text-xs rounded animate-fadein" data-idx="${i}" aria-label="Enganchar a ${escapeHtml(
+                playerNames[i]
+              )}">Enganchar</button>`
             : ""
         }
-      </td>`;
+      </div>
+      <div class="progress-bg" style="background-color:rgba(0,0,0,0.2);">
+        <div class="progress-fill" style="width:${progress * 100}%;background-color:${playerColors[i]};"></div>
+      </div>
+    </td>`;
         }
         attachEngancharEvents();
         updateAllTotals();
@@ -598,6 +610,10 @@
           `#totalRow td:nth-child(${playerIdx + 2}) span`
         );
         if (el) el.textContent = totals[playerIdx];
+        const fill = document.querySelector(
+          `#totalRow td:nth-child(${playerIdx + 2}) .progress-fill`
+        );
+        if (fill) fill.style.width = `${getProgress(playerIdx, totals) * 100}%`;
         syncStickyTotals();
       }
 
@@ -605,6 +621,16 @@
         document.getElementById("pozoTotal").textContent =
           "Pozo: $" + calcularPozo();
         lastTotals = getTotals();
+        lastTotals.forEach((t, i) => {
+          const el = document.querySelector(
+            `#totalRow td:nth-child(${i + 2}) span`
+          );
+          if (el) el.textContent = t;
+          const fill = document.querySelector(
+            `#totalRow td:nth-child(${i + 2}) .progress-fill`
+          );
+          if (fill) fill.style.width = `${getProgress(i, lastTotals) * 100}%`;
+        });
         syncStickyTotals();
         saveNow();
       }

--- a/styles.css
+++ b/styles.css
@@ -205,6 +205,19 @@ body {
 .highlight-col {
   background-color: #dbeafe !important;
 }
+.progress-bg {
+  width: 100%;
+  height: 6px;
+  border-radius: 4px;
+  margin-top: 0.25rem;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0%;
+  transition: width 0.3s ease;
+}
 /* Sticky header para mobile */
 @media (max-width: 700px) {
   thead tr th {


### PR DESCRIPTION
## Summary
- calculate per-player progress toward 100 points
- display colored progress bars in totals row
- keep progress bars up to date when scores change

## Testing
- `node --check app.js`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f5aa897c83238c9518c924a909a7