### PR TITLE
Rotate dealer each hand and persist index

### DIFF
--- a/app.js
+++ b/app.js
@@ -638,8 +638,13 @@
       }
 
       function nextDealer() {
-        if (getPlayerCount() === 0) return;
-        dealerIndex = (dealerIndex + 1) % getPlayerCount();
+        const vivos = getJugadoresVivos();
+        if (vivos.length === 0) return;
+        let next = vivos.find((i) => i > dealerIndex);
+        if (next === undefined) {
+          next = vivos[0];
+        }
+        dealerIndex = next;
         renderHeader();
         saveNow();
       }
@@ -986,6 +991,10 @@
 
       // Inicializar desde LS o default
       loadFromLS();
+      const vivosInit = getJugadoresVivos();
+      if (vivosInit.length && !vivosInit.includes(dealerIndex)) {
+        dealerIndex = vivosInit[0];
+      }
       lastDealerRound = getCurrentRoundIndex() - 1;
       renderHeader();
       renderTable();

--- a/app.js
+++ b/app.js
@@ -608,15 +608,16 @@
       }
 
       function handleInput(rondaIdx, playerIdx, value) {
+        const prevRound = getCurrentRoundIndex();
         roundsArr[rondaIdx][playerIdx] = value ? +value || 0 : "";
         checkGameEnd();
         updateTotal(playerIdx);
         renderTotalRow();
         const currentRound = getCurrentRoundIndex();
-        if (
-          getTotals()[playerIdx] > 100 &&
-          !shouldShowEnganchar(playerIdx, currentRound)
-        ) {
+        const totals = getTotals();
+        if (totals[playerIdx] > 100 && !shouldShowEnganchar(playerIdx, currentRound)) {
+          renderTable();
+        } else if (currentRound !== prevRound) {
           renderTable();
         }
         checkDealerRotation();

--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@
       let enganches = []; // { idx, round, ref, total }
       let playerColors = [];
       let saveTimeout;
+      let dealerIndex = 0;
 
       const isManualEnganchado = (idx) =>
         manualEnganches.some((e) => e.idx === idx);
@@ -27,6 +28,7 @@
             winnerIndex = data.winnerIndex ?? null;
             enganches = data.enganches || [];
             playerColors = data.playerColors || playerNames.map(() => generatePastelColor());
+            dealerIndex = data.dealerIndex ?? 0;
           } else {
             playerColors = playerNames.map(() => generatePastelColor());
           }
@@ -34,6 +36,9 @@
             for (let i = playerColors.length; i < playerNames.length; i++) {
               playerColors.push(generatePastelColor());
             }
+          }
+          if (dealerIndex >= playerNames.length) {
+            dealerIndex = 0;
           }
         } catch (e) {
           console.error("loadFromLS error", e);
@@ -55,6 +60,7 @@
               gameOver,
               winnerIndex,
               playerColors,
+              dealerIndex,
             })
           );
         } catch (e) {
@@ -184,6 +190,7 @@
             isManualEnganchado(i) ? "enganchado" : ""
           }" style="background-color:${playerColors[i]};color:${textColor};">
             <div class="flex items-center gap-1 justify-center">
+              ${i === dealerIndex ? '<span title="Reparte" class="dealer-icon text-lg">🂠</span>' : ''}
               <span class="editable cursor-pointer hover:underline" data-idx="${i}">${escapeHtml(
             name
           )}</span>
@@ -589,6 +596,13 @@
         saveNow();
       }
 
+      function nextDealer() {
+        if (getPlayerCount() === 0) return;
+        dealerIndex = (dealerIndex + 1) % getPlayerCount();
+        renderHeader();
+        saveNow();
+      }
+
       function removePlayer(index) {
         if (getPlayerCount() <= 1) {
           showNotif("Debe haber al menos un jugador", "bg-red-700");
@@ -597,6 +611,12 @@
         confirmAction("¿Eliminar este jugador?", () => {
           playerNames.splice(index, 1);
           playerColors.splice(index, 1);
+          if (index < dealerIndex) {
+            dealerIndex--;
+          }
+          if (dealerIndex >= playerNames.length) {
+            dealerIndex = 0;
+          }
           manualEnganches = manualEnganches
             .filter((e) => e.idx !== index)
             .map((e) => ({ ...e, idx: e.idx > index ? e.idx - 1 : e.idx }));
@@ -668,6 +688,7 @@
           gameOver = false;
           winnerIndex = null;
           enganches = [];
+          dealerIndex = 0;
           renderHeader();
           renderTable();
           updateAllTotals();
@@ -915,6 +936,7 @@
       renderTable();
       document.getElementById("addPlayerBtn").addEventListener("click", addPlayer);
       document.getElementById("resetScoresBtn").addEventListener("click", resetScores);
+      document.getElementById("nextDealerBtn").addEventListener("click", nextDealer);
 
       let deferredPrompt;
       window.addEventListener("beforeinstallprompt", (e) => {

--- a/index.html
+++ b/index.html
@@ -51,6 +51,13 @@
         Reiniciar Puntajes
       </button>
       <button
+        id="nextDealerBtn"
+        class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded transition"
+        aria-label="Siguiente mano"
+      >
+        Siguiente mano
+      </button>
+      <button
         id="installBtn"
         class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded transition"
         style="display: none"


### PR DESCRIPTION
## Summary
- Persist `dealerIndex` in state and localStorage
- Highlight current dealer with a card icon
- Add "Siguiente mano" button to rotate dealer

## Testing
- `node --check app.js`
- `npm test` *(fails: Error: no test specified)*
