### PR TITLE
feat: add undo redo round history with log

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,22 @@
         Siguiente mano
       </button>
       <button
+        id="undoBtn"
+        class="bg-gray-500 hover:bg-gray-700 text-white px-4 py-2 rounded transition"
+        aria-label="Deshacer"
+        disabled
+      >
+        Deshacer
+      </button>
+      <button
+        id="redoBtn"
+        class="bg-gray-500 hover:bg-gray-700 text-white px-4 py-2 rounded transition"
+        aria-label="Rehacer"
+        disabled
+      >
+        Rehacer
+      </button>
+      <button
         id="installBtn"
         class="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded transition"
         style="display: none"
@@ -86,6 +102,10 @@
         </tfoot>
       </table>
     </div>
+    <div
+      id="roundLog"
+      class="mt-4 w-full max-w-3xl mx-auto text-sm"
+    ></div>
     <script src="app.js" defer></script>
     <div id="totalStickyBar" style="display: none"></div>
     <script>


### PR DESCRIPTION
## Summary
- keep a history of rounds and totals
- add Deshacer and Rehacer buttons to navigate snapshots
- display a simple timestamped round log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6231608a08323a9106ea939d9443e